### PR TITLE
Fix word omission in Monad Transformers section

### DIFF
--- a/slideshow.md
+++ b/slideshow.md
@@ -996,7 +996,7 @@ layers and to explicit ``lift`` and ``return`` values between each the layers.
 ~~~~ {.haskell include="src/transformer.hs"}
 ~~~~
 
-The fundamental limitation of this approach is that ourselves ``lift.lift.lift``ing and
+The fundamental limitation of this approach is that we find ourselves ``lift.lift.lift``ing and
 ``return.return.return``ing a lot.
 
 Newtype Deriving


### PR DESCRIPTION
I'd rather keep reading and find some more substantial stuff (if any), but I should have been asleep a long time ago...
