### PR TITLE
make "includes" a dependency to compile markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ cabal.sandbox.config
 dist/
 *.hi
 *.o
-
+includes
+slideshow.html

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ HTML = slideshow.html
 
 all: $(HTML)
 
-%.html: %.md
+includes: includes.hs
+	ghc --make $<
+
+%.html: %.md includes
 	# $(PANDOC) -c $(STYLE) --template $(TEMPLATE) -s -f $(IFORMAT) -t html $(FLAGS) -o $@ $<
 	./includes < $< | $(PANDOC) -c $(STYLE) --template $(TEMPLATE) -s -f $(IFORMAT) -t html $(FLAGS) -o $@
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ If for some reason you want to compile the HTML page yourself, then you'll need 
 against Pandoc and then run make to build the page.
 
 ```bash
-$ ghc --make includes.hs
 $ make
 ```
 


### PR DESCRIPTION
This way running `make` will compile the `includes.hs` if it's out of date. 
