### PR TITLE
corrects type signature for `ask` in the reader-monad section

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1095,7 +1095,7 @@ instance (Monad m) => MonadReader r (ReaderT r m) where
 So hypothetically the three variants of ask would be:
 
 ```haskell
-ask :: Reader r a -> a
+ask :: Reader r a
 ask :: Monad m => ReaderT r m r
 ask :: MonadReader r m => m r
 ```


### PR DESCRIPTION
The type signature for ask should be:

ask :: Reader r a

and not:

ask :: Reader r a -> a

(thanks for the great guide!)
