### PR TITLE
Update pipes_io.hs

### DIFF
--- a/src/25-streaming/pipes_io.hs
+++ b/src/25-streaming/pipes_io.hs
@@ -15,5 +15,6 @@ b = do
      | n `mod` 5  == 0 -> yield "Fizz"
      | n `mod` 3  == 0 -> yield "Buzz"
      | otherwise       -> return ()
+  b
 
 main = runEffect $ a >-> b >-> P.stdoutLn


### PR DESCRIPTION
That the check must be repeated was left off.   As it stands it's a one-await-only pipe.
