### PR TITLE
Change type signature.

### DIFF
--- a/src/32-lenses/lens_impl.hs
+++ b/src/32-lenses/lens_impl.hs
@@ -9,7 +9,7 @@ type Lens' a b = forall f. Functor f => (b -> f b) -> (a -> f a)
 newtype Const x a  = Const { runConst :: x } deriving Functor
 newtype Identity a = Identity { runIdentity :: a } deriving Functor
 
-lens :: (s -> a) -> (s -> a -> s) -> Lens' s a
+lens :: (a -> b) -> (a -> b -> a) -> Lens' a b
 lens getter setter f a = fmap (setter a) (f (getter a))
 
 set :: Lens' a b -> b -> a -> a


### PR DESCRIPTION
Change from `Lens' s a` to `Lens' a b` to maintain consistency.