### PR TITLE
Fixes #46.

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -9545,7 +9545,7 @@ over l f a = set l (f (get l a)) a
 infixl 1 &
 infixr 4 .~
 infixr 4 %~
-infixr 8 ^.
+infixl 8 ^.
 
 (&) :: a -> (a -> b) -> b
 (&) = flip ($)


### PR DESCRIPTION
After discussing on #haskell-lens, I figured out why this was breaking
here: the associativity was wrong here. I haven't worked out the second
equation yet, but will patch that in case the equation doesn't fit.

Also Edward Kmett's lens library also has left associativity for the
same operator:
http://hackage.haskell.org/package/lens-4.8/docs/Control-Lens-Getter.html#v:-94-.