### PR TITLE
Remove extra apostrophes in tutorial.md

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -2253,7 +2253,7 @@ contains diverging terms.
 ~~~~ {.haskell include="src/05-laziness/nodiverge.hs"}
 ~~~~
 
-In a strict language like OCaml ( ignoring it's suspensions for the moment ),
+In a strict language like OCaml ( ignoring its suspensions for the moment ),
 the same program diverges.
 
 ~~~~ {.haskell include="src/05-laziness/diverge.ml"}
@@ -2264,7 +2264,7 @@ Evaluation of a thunk is called *forcing* the thunk. The result is an *update*,
 a referentially transparent effect, which replaces the memory representation of
 the thunk with the computed value. The fundamental idea is that a thunk is only
 updated once ( although it may be forced simultaneously in a multi-threaded
-environment ) and it's resulting value is shared when referenced subsequently.
+environment ) and its resulting value is shared when referenced subsequently.
 
 The command ``:sprintf`` can be used to introspect the state of unevaluated
 thunks inside an expression without forcing evaluation. For instance:
@@ -2289,7 +2289,7 @@ a = 1 : 2 : 3 : 4 : 5 : 6 : 7 : 8 : 9 : 10 : 11 : _
 b = _ : _ : _ : _ : _ : _ : _ : _ : _ : _ : 12 : _
 ```
 
-While a thunk is being computed it's memory representation is replaced with a
+While a thunk is being computed its memory representation is replaced with a
 special form known as *blackhole* which indicates that computation is ongoing
 and allows a short circuit for when a computation might depend on it itself to
 complete. The implementation of this is some of the more subtle details of the
@@ -3698,7 +3698,7 @@ Free theorems
 -------------
 
 A universally quantified type-variable actually implies quite a few rather deep
-properties about the implementation of a function that can be deduced from it's
+properties about the implementation of a function that can be deduced from its
 type signature. For instance the identity function in Haskell is guaranteed to
 only have one implementation since the only information that the information
 that can present in the body 
@@ -3830,7 +3830,7 @@ invariants about scope and use of specific type variables. For example the ST
 monad uses a second rank type to prevent the capture of references between ST
 monads with separate state threads where the ``s`` type variable is bound within
 a rank-2 type and cannot escape, statically guaranteeing that the implementation
-details of the ST internals can't leak out and thus ensuring it's referential
+details of the ST internals can't leak out and thus ensuring its referential
 transparency.
 
 Existential Quantification
@@ -3922,7 +3922,7 @@ Scoped Type Variables
 ---------------------
 
 Normally the type variables used within the toplevel signature for a function
-are only scoped to the type-signature and not the body of the function and it's
+are only scoped to the type-signature and not the body of the function and its
 rigid signatures over terms and let/where clauses.  Enabling
 ``-XScopedTypeVariables`` loosens this restriction allowing the type variables
 mentioned in the toplevel to be scoped within the value-level body of a function
@@ -4253,8 +4253,8 @@ type (->) a b = a -> b          -- b ^ a
 ```
 
 Intuitively it follows the notion that the cardinality of set of inhabitants of a type can always be given as
-a function of the number of it's holes. A product type admits a number of inhabitants as a function of the
-product (i.e. cardinality of the Cartesian product), a sum type as as the sum of it's holes and a function
+a function of the number of its holes. A product type admits a number of inhabitants as a function of the
+product (i.e. cardinality of the Cartesian product), a sum type as as the sum of its holes and a function
 type as the exponential of the span of the domain and codomain.
 
 ```haskell
@@ -4303,7 +4303,7 @@ hylo :: Functor f => Algebra f b -> Coalgebra f a -> a -> b
 ```
 
 In Haskell a F-algebra in a functor ``f a`` together with function ``f a -> a``.
-A colagebra reverses the function. For a functor ``f`` we can form it's
+A colagebra reverses the function. For a functor ``f`` we can form its
 recursive unrolling using the recursive ``Fix`` newtype wrapper.
 
 
@@ -4743,7 +4743,7 @@ multiparamater typeclass instances with the same ``a`` but different ``b``.
 
 Now let's make things not so simple. Turning on ``UndecidableInstances`` loosens
 the constraint on context reduction can only allow constraints of the class to
-become structural smaller than it's head. As a result implicit computation can
+become structural smaller than its head. As a result implicit computation can
 now occur *within in the type class instance search*. Combined with a type-level
 representation of Peano numbers we find that we can encode basic arithmetic at
 the type-level.
@@ -4882,7 +4882,7 @@ datatypes.
 * ``phantom``
 
 They were added to the language to address a rather nasty and long-standing bug
-around the correspondence between a newtype and it's runtime representation. The
+around the correspondence between a newtype and its runtime representation. The
 fundamental distinction that roles introduce is there are two notions of type
 equality:
 
@@ -4981,7 +4981,7 @@ Types       Logic
 ``A × B``   A ∧ B
 ``A -> B``  A ⇒ B
 
-In dependently typed languages we can exploit this result to it's full extent,
+In dependently typed languages we can exploit this result to its full extent,
 in Haskell we don't have the strength that dependent types provide but can still
 prove trivial results. For example, now we can model a type level function for
 addition and provide a small proof that zero is an additive identity.
@@ -5219,7 +5219,7 @@ lifting types to the kind level.
 Vectors
 -------
 
-Using this new structure we can create a ``Vec`` type which is parameterized by it's length as well as it's
+Using this new structure we can create a ``Vec`` type which is parameterized by its length as well as its
 element type now that we have a kind language rich enough to encode the successor type in the kind signature
 of the generalized algebraic datatype. 
 
@@ -5534,7 +5534,7 @@ TemplateHaskell or a Generic deriving.
 HLists
 ------
 
-A heterogeneous list is a cons list whose type statically encodes the ordered types of of it's values.
+A heterogeneous list is a cons list whose type statically encodes the ordered types of of its values.
 
 ~~~~ {.haskell include="src/17-promotion/hlist.hs"}
 ~~~~
@@ -6253,7 +6253,7 @@ series expansions for the expressions when performing operations like arithmetic
 or transcendental functions without loosing precision when performing
 intermediate computations. Then when simply slice of a fixed number of terms and
 approximate the resulting number to a desired precision. This approach is not
-without it's limitations and caveats ( notably that it may diverge ) but works
+without its limitations and caveats ( notably that it may diverge ) but works
 quite well in practice.
 
 ```haskell
@@ -6843,7 +6843,7 @@ rdeepseq x = rseq (force x)
 ```
 
 We now can create a "higher order" strategy that takes two strategies and itself yields a a computation which
-when evaluated uses the passed strategies in it's scheduling.
+when evaluated uses the passed strategies in its scheduling.
 
 ~~~~ {.haskell include="src/22-concurrency/strategies_param.hs"}
 ~~~~
@@ -6964,7 +6964,7 @@ us write code to generate parsers which themselves looks very similar to the par
 ``<|>``       The choice operator tries to parse the first argument before proceeding to the second. Can be chained sequentially to a generate a sequence of options.
 ``many``      Consumes an arbitrary number of patterns matching the given pattern and returns them as a list.
 ``many1``     Like many but requires at least one match. 
-``optional``  Optionally parses a given pattern returning it's value as a Maybe.
+``optional``  Optionally parses a given pattern returning its value as a Maybe.
 ``try``       Backtracking operator will let us parse ambiguous matching expressions and restart with a different pattern.
 
 There are two styles of writing Parsec, one can choose to write with monads or with applicatives.
@@ -7751,7 +7751,7 @@ f $ x =  f x
 
 Having to enter a secondary closure every time we used ``($)`` would introduce
 an enormous overhead. Fortunately GHC has a pass to eliminate small functions
-like this by simply replacing the function call with the body of it's definition
+like this by simply replacing the function call with the body of its definition
 at appropriate call-sites. There compiler contains a variety heuristics for
 determining when this kind of substitution is appropriate and the potential
 costs involved.
@@ -7925,7 +7925,7 @@ entirely free.
 
 Many C++ compilers or whole program optimizing compilers do the opposite
 however, they explicitly specialize each and every function at the call site
-replacing the overloaded function with it's type-specific implementation. We can
+replacing the overloaded function with its type-specific implementation. We can
 selectively enable this kind of behavior using class specialization.
 
 ~~~~ {.haskell include="src/29-ghc/specialize.hs"}
@@ -8496,7 +8496,7 @@ Cmm is GHC's complex internal intermediate representation that maps directly
 onto the generated code for the compiler target. Cmm code code generated from
 Haskell is CPS-converted, all functions never return a value, they simply call
 the next frame in the continuation stack. All evaluation of functions proceed by
-indirectly jumping to a code object with it's arguments placed on the stack by
+indirectly jumping to a code object with its arguments placed on the stack by
 the caller.
 
 This is drastically different than C's evaluation model, where are placed on the
@@ -8553,7 +8553,7 @@ one to the other.
 
 There are generally two parts to every Cmm definition, the **info table** and
 the **entry code**. The info table maps directly ``StgInfoTable`` struct and
-contains various fields related to the type of the closure, it's payload, and
+contains various fields related to the type of the closure, its payload, and
 references. The code objects are basic blocks of generated code that correspond
 to the logic of the Haskell function/constructor.
 
@@ -9215,7 +9215,7 @@ data QuasiQuoter = QuasiQuoter
 ```
 
 The logic evaluating, splicing, and introspecting compile-time values is embedded within the Q monad, which
-has a ``runQ`` which can be used to evaluate it's context. These functions of this monad is deeply embedded in
+has a ``runQ`` which can be used to evaluate its context. These functions of this monad is deeply embedded in
 the implementation of GHC.
 
 ```haskell
@@ -9276,7 +9276,7 @@ Using
 [Language.Haskell.TH](http://hackage.haskell.org/package/template-haskell-2.4.0.0/docs/Language-Haskell-TH-Syntax.html#t:Dec)
 we can piece together Haskell AST element by element but subject to our own custom logic to generate the code.
 This can be somewhat painful though as the source-language (called ``HsSyn``) to Haskell is enormous,
-consisting of around 100 nodes in it's AST many of which are dependent on the state of language pragmas.
+consisting of around 100 nodes in its AST many of which are dependent on the state of language pragmas.
 
 ```haskell
 -- builds the function (f = \(a,b) -> a)
@@ -9457,7 +9457,7 @@ Trying it out by splicing code at the expression level, type level and as patter
 ~~~~ {.haskell include="src/31-template-haskell/splice_singleton.hs"}
 ~~~~
 
-The [singletons](https://hackage.haskell.org/package/singletons) package takes this idea to it's logical
+The [singletons](https://hackage.haskell.org/package/singletons) package takes this idea to its logical
 conclusion allow us to toplevel declarations of seemingly regular Haskell syntax with singletons spliced in,
 the end result resembles the constructions in a dependently typed language if one squints hard enough.
 
@@ -9489,8 +9489,8 @@ in scope:
 
 **<span style="color:red">WARNING</span>: The ``lens`` library is considered by
 many Haskellers to be deeply pathological and introduces a needless amount of
-complexity. Some care should taken when considering it's use, it is included
-here for information only and not as endorsement for it's use. Consider
+complexity. Some care should taken when considering its use, it is included
+here for information only and not as endorsement for its use. Consider
 ``lens-family-core`` or ``fclabels`` instead.**
 
 Should I use lens library?
@@ -9510,7 +9510,7 @@ idiosyncratic with respect to the rest of the ecosystem.
 van Laarhoven Lenses
 --------------------
 
-At it's core a lens is a form of coupled getter and setter functions as a value under an existential functor.
+At its core a lens is a form of coupled getter and setter functions as a value under an existential functor.
 
 ```haskell
 --         +---- a : Type of structure


### PR DESCRIPTION
Changed "it's" into "its" when used as a possessive.