### PR TITLE
Fix syntax errors in System F code

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -3767,7 +3767,7 @@ e : x          -- variables
 ```haskell
 id : ∀ t. t -> t
 id = Λt. λx:t. x
-id = (\ (@ t) (x :: t) -> x
+-- id = \ (@ t) (x :: t) -> x
 
 tr :: ∀ a. ∀ b. a -> b -> a
 tr = Λa. Λb. λx:a. λy:b. x
@@ -3776,11 +3776,11 @@ fl :: ∀ a. ∀ b. a -> b -> b
 fl = Λa. Λb. λx:a. λy:b. y
 
 nil :: ∀ a. [a]
-nil = Λa. Λb. -> λ (z :: b) . λ (f :: a -> b -> b). z
+nil = Λa. Λb. λz:b. λf:(a -> b -> b). z
 
-cons :: forall a. a -> [a] -> [a]
-cons = Λ a -> λ(x :: a) -> λ(xs :: forall b. b -> (a -> b -> b) -> b)
-    -> Λ b -> λ(z :: b) -> λ(f :: a -> b -> b) -> f x (xs @ b z f)
+cons :: ∀ a. a -> [a] -> [a]
+cons = Λa. λx:a. λxs:(∀ b. b -> (a -> b -> b) -> b)
+    -> Λb -> λz:b -> λf : (a -> b -> b) -> f x (xs_b z f)
 ```
 
 Normally when Haskell's typechecker infers a type signature it places all quantifiers of type variables at the

--- a/tutorial.md
+++ b/tutorial.md
@@ -3779,8 +3779,8 @@ nil :: ∀ a. [a]
 nil = Λa. Λb. λz:b. λf:(a -> b -> b). z
 
 cons :: ∀ a. a -> [a] -> [a]
-cons = Λa. λx:a. λxs:(∀ b. b -> (a -> b -> b) -> b)
-    -> Λb -> λz:b -> λf : (a -> b -> b) -> f x (xs_b z f)
+cons = Λa. λx:a. λxs:(∀ b. b -> (a -> b -> b) -> b).
+    Λb. λz:b. λf : (a -> b -> b). f x (xs_b z f)
 ```
 
 Normally when Haskell's typechecker infers a type signature it places all quantifiers of type variables at the

--- a/tutorial.md
+++ b/tutorial.md
@@ -3761,7 +3761,7 @@ e : x          -- variables
   | λ(x:t).e   -- value abstraction
   | e1 e2      -- value application
   | Λa.e       -- type abstraction 
-  | e t        -- type application
+  | e_t        -- type application
 ```
 
 ```haskell

--- a/tutorial.md
+++ b/tutorial.md
@@ -3764,23 +3764,36 @@ e : x          -- variables
   | e_t        -- type application
 ```
 
+Here's an example with equivalents of GHC core in comments.
+
 ```haskell
 id : ∀ t. t -> t
 id = Λt. λx:t. x
+-- id :: forall t. t -> t
 -- id = \ (@ t) (x :: t) -> x
 
-tr :: ∀ a. ∀ b. a -> b -> a
+tr : ∀ a. ∀ b. a -> b -> a
 tr = Λa. Λb. λx:a. λy:b. x
+-- tr :: forall a b. a -> b -> a
+-- tr = \ (@ a) (@ b) (x :: a) (y :: b) -> x
 
-fl :: ∀ a. ∀ b. a -> b -> b
+fl : ∀ a. ∀ b. a -> b -> b
 fl = Λa. Λb. λx:a. λy:b. y
+-- fl :: forall a b. a -> b -> b
+-- fl = \ (@ a) (@ b) (x :: a) (y :: b) -> y
 
-nil :: ∀ a. [a]
+nil : ∀ a. [a]
 nil = Λa. Λb. λz:b. λf:(a -> b -> b). z
+-- nil :: forall a. [a]
+-- nil = \ (@ a) (@ b) (z :: b) (f :: a -> b -> b) -> z
 
-cons :: ∀ a. a -> [a] -> [a]
+cons : ∀ a. a -> [a] -> [a]
 cons = Λa. λx:a. λxs:(∀ b. b -> (a -> b -> b) -> b).
     Λb. λz:b. λf : (a -> b -> b). f x (xs_b z f)
+-- cons :: forall a. a
+--       -> (forall b. (a -> b -> b) -> b) -> (forall b. (a -> b -> b) -> b)
+-- cons = \ (@ a) (x :: a) (xs :: forall b. (a -> b -> b) -> b)
+--     (@ b) (z :: b) (f :: a -> b -> b) -> f x (xs @ b z f)
 ```
 
 Normally when Haskell's typechecker infers a type signature it places all quantifiers of type variables at the

--- a/tutorial.md
+++ b/tutorial.md
@@ -3764,7 +3764,7 @@ e : x          -- variables
   | e_t        -- type application
 ```
 
-Here's an example with equivalents of GHC core in comments.
+An example with equivalents of GHC Core in comments:
 
 ```haskell
 id : ∀ t. t -> t


### PR DESCRIPTION
Fixed syntax errors in System F code. Changed the definition a bit to improve clarity.