### PR TITLE
fix the description of the numeric table in tutorial.md

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -6174,7 +6174,7 @@ class (RealFrac a, Floating a) => RealFloat a
 
 ![](img/numerics.png)
 
-Conversions between concrete numeric types (from : top row, to : left column )
+Conversions between concrete numeric types ( from : left column, to : top row )
 is accomplished with several generic functions.
 
          Double       Float         Int           Word           Integer       Rational


### PR DESCRIPTION
The direction of conversions indicated in the description of the numeric table seems reverse.