### PR TITLE
A working solution for including the extensions.html into tutorial.md.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ includes: includes.hs
 	ghc --make $<
 
 %.html: %.md includes
-	./includes < $< | $(PANDOC) -c $(STYLE) --template $(TEMPLATE) -s -f $(IFORMAT) -t html $(FLAGS) -o $@
+	./includes < $<  \
+	| $(PANDOC) -c $(STYLE) --template $(TEMPLATE) -s -f $(IFORMAT) -t html $(FLAGS) \
+	| sed '/<extensions>/r extensions.html' > $@
 
 %.epub: %.md includes
 	./includes < $< | $(PANDOC) -f $(IFORMAT) -t epub $(FLAGS) -o $@

--- a/tutorial.md
+++ b/tutorial.md
@@ -1874,8 +1874,7 @@ as an arbitrary baseline let's consider ``FlexibleInstances`` and ``OverloadedSt
 * *Historical* implies that one shouldn't use this extension, it's in GHC purely for backwards compatibility.
   Sometimes these are dangerous to enable.
 
-~~~~ {literal="extensions.html"}
-~~~~
+<extensions></extensions>
 
 See: [GHC Extension Reference](http://www.haskell.org/ghc/docs/7.8.2/html/users_guide/flag-reference.html#idp14615552)
 


### PR DESCRIPTION
http://dev.stephendiehl.com/hask/ has extensions.html show up as raw html 

This is a fix.