### PR TITLE
VM.unsafeWith instead of VM.unsafeToForeignPtr0

### DIFF
--- a/src/21-ffi/ffi.hs
+++ b/src/21-ffi/ffi.hs
@@ -3,8 +3,6 @@
 
 import Foreign.Ptr
 import Foreign.C.Types
-import Foreign.ForeignPtr
-import Foreign.ForeignPtr.Unsafe
 
 import qualified Data.Vector.Storable as V
 import qualified Data.Vector.Storable.Mutable as VM
@@ -12,14 +10,11 @@ import qualified Data.Vector.Storable.Mutable as VM
 foreign import ccall safe "sort" qsort
     :: Ptr a -> CInt -> CInt -> IO ()
 
-vecPtr :: VM.MVector s CInt -> ForeignPtr CInt
-vecPtr = fst . VM.unsafeToForeignPtr0
-
 main :: IO ()
 main = do
   let vs = V.fromList ([1,3,5,2,1,2,5,9,6] :: [CInt])
   v <- V.thaw vs
-  withForeignPtr (vecPtr v) $ \ptr -> do
+  VM.unsafeWith v $ \ptr -> do
     qsort ptr 0 9
   out <- V.freeze v
   print out


### PR DESCRIPTION
Less lines with seemingly the same effect. Is there a technical or pedagogical benefit to opt for withForeignPtr wrapped around VM.unsafeToForeignPtr0, versus VM.unsafeWith?
