### PR TITLE
Correct the type signature of Data.Traversable.traverse

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -2758,7 +2758,7 @@ structure left-to-right within an applicative context.
 
 ```haskell
 class (Functor f, Foldable f) => Traversable f where
-  traverse :: Applicative g => f (g a) -> g (f a)
+  traverse :: Applicative g => (a -> g b) -> f a -> g (f b)
 
 class Foldable f where
   foldMap :: Monoid m => (a -> m) -> f a -> m


### PR DESCRIPTION
The type signature of `traverse` is actually that of `sequenceA`.  Modified with the correct signature for `traverse`.

An alternative would be to just change `traverse` to `sequenceA;, and leave the signature alone; that would work too.