### PR TITLE
Typo, (&&) type family

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -5561,8 +5561,8 @@ type family Sum (ns :: [Nat]) :: Nat where
 Kind Indexed Type Families
 --------------------------
 
-Just as typeclasses are normally indexed on types, classes can also be indexed on kinds with the kinds given
-as explicit kind signatures on type variables.
+Just as typeclasses are normally indexed on types, type families can also be indexed on kinds with the kinds
+given as explicit kind signatures on type variables.
 
 ```haskell
 type family (a :: k) == (b :: k) :: Bool
@@ -5587,6 +5587,10 @@ type family EqList a b where
   EqList '[]        '[]        = True
   EqList (h1 ': t1) (h2 ': t2) = (h1 == h2) && (t1 == t2)
   EqList a          b          = False
+
+type family a && b where
+  True && True = True
+  a    && a    = False
 ```
 
 Promoted Symbols


### PR DESCRIPTION
I tried the example for Kind Indexed Type Families locally and was surprised that it compiled fine with `-XUndecidableInstances`:

    type family (a :: k) == (b :: k) :: Bool
    type instance a == b = EqStar a b
    type instance a == b = EqArrow a b
    type instance a == b = EqBool a b

    ...

I guess I do not understand that extension, why is GHC not complaining about instance overlap here?

Lastly, I know it's just an example, but isn't `EqStar` instance alone would be enough as it can already handle the cases for `EqArrow` and `EqBool`?