### PR TITLE
Edits to Eightfold Path, Monadic Myths, and Laws Sections

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1376,7 +1376,7 @@ Eightfold Path to Monad Satori
 ------------------------------
 
 Much ink has been spilled waxing lyrical about the supposed mystique of monads.
-Instead I suggest a path to enlightenment:
+Instead, I suggest a path to enlightenment:
 
 1. Don't read the monad tutorials.
 2. No really, don't read the monad tutorials.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1434,7 +1434,7 @@ function ``f``, this expression is exactly equivalent to ``f a``.
 **Law 1**
 
 ```haskell
-return a >>= f ≡ f a
+return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
 ```
 
 **Law 2**

--- a/tutorial.md
+++ b/tutorial.md
@@ -1485,6 +1485,21 @@ pass a monadic value to ``return`` does not change the initial value.
 m >>= return ≡ m        -- 'm' here refers to a value that has type 'm a'
 ```
 
+A more explicit way to write the second Monad law exists.  In this following
+example code, the first expression shows how the second law applies to values
+represented by
+[non-nullary](https://wiki.haskell.org/Constructor#Type_constructor) type
+constructors. The second snippet shows how a value represented by a nullary type
+constructor works within the context of the second law.
+
+```haskell
+(SomeMonad x) >>= return ≡ SomeMonad x    -- 'SomeMonad x' has type 'm a' just
+                                          -- 'm' from the first example of the
+                                          -- second law
+
+NullaryMonadType >>= return ≡ NullaryMonadType
+```
+
 While the first two laws are relatively clear, the third law may be more
 difficult to understand. This law states that when a monadic value ``m`` is
 passed through ``(>>=)`` to the function ``f`` and then the result of that

--- a/tutorial.md
+++ b/tutorial.md
@@ -1421,8 +1421,9 @@ described in the typeclass definition:
 ```haskell
 class Monad m where
   (>>=)  :: m a -> (a -> m b) -> m b
-  return :: a -> m a                     -- N.B. 'm' refers to a higher-kinded  type
-                                         -- (e.g., Maybe, List, Either, etc.) that
+  return :: a -> m a                     -- N.B. 'm' refers to a type constructor
+                                         -- (e.g., Maybe, Either, etc.) that
+                                         -- implements the Monad typeclass
 ```
 
 Any preconceptions one might have for the word "return" should be discarded:

--- a/tutorial.md
+++ b/tutorial.md
@@ -1468,6 +1468,10 @@ function ``f``, this expression is exactly equivalent to ``f a``.
 return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
 ```
 
+The second law states that a monadic value ``m`` passed through ``(>>=)``
+into ``return`` is exactly equivalent to itself. In other words, using bind to
+pass a monadic value to ``return`` does not change the initial value.
+
 **Law 2**
 
 ```haskell

--- a/tutorial.md
+++ b/tutorial.md
@@ -1424,7 +1424,9 @@ class Monad m where
   (>>=)  :: m a -> (a -> m b) -> m b
   return :: a -> m a
 ```
-Together with three laws that all monad instances must satisfy.
+
+In addition to specific implementations of ``(>>=)`` and ``return``, all monad
+instance must satisfy three laws.
 
 **Law 1**
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1420,9 +1420,9 @@ arity described in the typeclass definition:
 
 ```haskell
 class Monad m where
-  return :: a -> m a                     -- N.B. 'm' refers to a type constructor
-                                         -- (e.g., Maybe, Either, etc.) that
-                                         -- implements the Monad typeclass
+  return :: a -> m a                    -- N.B. 'm' refers to a type constructor
+                                        -- (e.g., Maybe, Either, etc.) that
+                                        -- implements the Monad typeclass
 
   (>>=)  :: m a -> (a -> m b) -> m b
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -1507,8 +1507,10 @@ difficult to understand. This law states that when a monadic value ``m`` is
 passed through ``(>>=)`` to the function ``f`` and then the result of that
 expression is passed to ``>>= g``, the entire expression is exactly equivalent
 to passing ``m`` to a lamda expression that takes one parameter ``x`` and
-outputs the function ``f`` applied to ``x``, with the resultant value of that
-expression passed through ``(>>=)`` to the function ``g``.
+outputs the function ``f`` applied to ``x``. By the definition of bind, ``f x``
+*must* return a value wrapped in the same Monad. Because of this property, the
+resultant value of that expression can be  passed through ``(>>=)`` to the
+function ``g``, which also returns a monadic value.
 
 ```haskell
 (m >>= f) >>= g ≡ m >>= (\x -> f x >>= g)  -- Like in the last law, 'm' has

--- a/tutorial.md
+++ b/tutorial.md
@@ -1440,6 +1440,14 @@ This infix takes two arguments. On its left side is a value with type ``m a``,
 while on the right side is a function with type ``(a -> m b)``. The bind
 operation results in a final value of type ``m b``.
 
+A third, auxiliary function (``(>>)``) is defined in terms of the bind operation
+that discards its argument.
+
+```haskell
+(>>) :: Monad m => m a -> m b -> m b
+m >> k = m >>= \_ -> k
+```
+
 Laws
 ----
 
@@ -1465,14 +1473,6 @@ m >>= return ≡ m
 
 ```haskell
 (m >>= f) >>= g ≡ m >>= (\x -> f x >>= g)
-```
-
-There is an auxiliary function (``(>>)``) defined in terms of the bind operation
-that discards its argument.
-
-```haskell
-(>>) :: Monad m => m a -> m b -> m b
-m >> k = m >>= \_ -> k
 ```
 
 See: [Monad Laws](http://wiki.haskell.org/Monad_laws)

--- a/tutorial.md
+++ b/tutorial.md
@@ -1440,11 +1440,11 @@ This infix takes two arguments. On its left side is a value with type ``m a``,
 while on the right side is a function with type ``(a -> m b)``. The bind
 operation results in a final value of type ``m b``.
 
-In addition to specific implementations of ``(>>=)`` and ``return``, all monad
-instance must satisfy three laws.
-
 Laws
 ----
+
+In addition to specific implementations of ``(>>=)`` and ``return``, all monad
+instance must satisfy three laws.
 
 The first law says that when ``return a`` is passed through a ``(>>=)`` into a
 function ``f``, this expression is exactly equivalent to ``f a``.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1478,10 +1478,14 @@ pass a monadic value to ``return`` does not change the initial value.
 m >>= return ≡ m        -- 'm' here refers to a value that has type 'm a'
 ```
 
+
 **Law 3**
 
 ```haskell
-(m >>= f) >>= g ≡ m >>= (\x -> f x >>= g)
+(m >>= f) >>= g ≡ m >>= (\x -> f x >>= g)  -- Like in the last law, 'm' has
+                                           -- has type 'm a'. The functions 'f'
+                                           -- and 'g' have types '(a -> m b)'
+                                           -- and '(b -> m c)' respectively
 ```
 
 See: [Monad Laws](http://wiki.haskell.org/Monad_laws)

--- a/tutorial.md
+++ b/tutorial.md
@@ -1406,6 +1406,7 @@ The following are all **false**:
 * Monads are a "back-door" in the language to perform side-effects.
 * Monads are an embedded imperative language inside Haskell.
 * Monads require knowing abstract mathematics.
+* Monads are unique to Haskell.
 
 See: [What a Monad Is Not](http://wiki.haskell.org/What_a_Monad_is_not)
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1415,8 +1415,8 @@ Monadic Methods
 
 Monads are not complicated. They are implemented as a typeclass with two
 methods, ``return`` and ``(>>=)`` (pronounced "bind"). In order to implement
-a Monad instance, these two functions must be defined in accordance with arity
-described in the typeclass definition:
+a Monad instance, these two functions must be defined in accordance with the
+arity described in the typeclass definition:
 
 ```haskell
 class Monad m where

--- a/tutorial.md
+++ b/tutorial.md
@@ -1478,6 +1478,13 @@ pass a monadic value to ``return`` does not change the initial value.
 m >>= return ≡ m        -- 'm' here refers to a value that has type 'm a'
 ```
 
+While the first two laws are relatively clear, the third law may be more
+difficult to understand. This law states that when a monadic value ``m`` is
+passed through ``(>>=)`` to the function ``f`` and then the result of that
+expression is passed to ``>>= g``, the entire expression is exactly equivalent
+to passing ``m`` to a lamda expression that takes one parameter ``x`` and
+outputs the function ``f`` applied to ``x``, with the resultant value of that
+expression passed through ``(>>=)`` to the function ``g``.
 
 **Law 3**
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1435,6 +1435,11 @@ Instead of being the final arbiter of what value a function
 produces, ``return`` in Haskell injects a value of type ``a`` into a monadic
 context (e.g., Maybe, Either, etc.).
 
+The other function essential to implementing a Monad instance is ``(>>=)``.
+This infix takes two arguments. On its left side is a value with type ``m a``,
+while on the right side is a function with type ``(a -> m b)``. The bind
+operation results in a final value of type ``m b``.
+
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1413,8 +1413,8 @@ See: [What a Monad Is Not](http://wiki.haskell.org/What_a_Monad_is_not)
 Laws
 ----
 
-Monads are not complicated, the implementation is a typeclass with two
-functions, ``(>>=)`` pronounced "bind" and ``return``. Any preconceptions one
+Monads are not complicated. They are implemented as a typeclass with two
+functions, ``(>>=)`` (pronounced "bind") and ``return``. Any preconceptions one
 might have for the word "return" should be discarded: It has an entirely
 different meaning in the context of Haskell.
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1414,7 +1414,7 @@ Monadic Methods
 ---------------
 
 Monads are not complicated. They are implemented as a typeclass with two
-functions, ``return`` and ``(>>=)`` (pronounced "bind"). In order to implement
+methods, ``return`` and ``(>>=)`` (pronounced "bind"). In order to implement
 a Monad instance, these two functions must be defined in accordance with arity
 described in the typeclass definition:
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1380,7 +1380,7 @@ Instead, I suggest a path to enlightenment:
 
 1. Don't read the monad tutorials.
 2. No really, don't read the monad tutorials.
-3. Learn about Haskell types.
+3. Learn about [Haskell types](http://book.realworldhaskell.org/read/types-and-functions.html).
 4. Learn what a typeclass is.
 5. Read the [Typeclassopedia](http://wiki.haskell.org/Typeclassopedia).
 6. Read the monad definitions.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1468,6 +1468,13 @@ function ``f``, this expression is exactly equivalent to ``f a``.
 return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
 ```
 
+In discussing the next two laws, we'll refer to a value ``m``. This notation is
+shorthand for value wrapped in a monadic context. Such a value has type ``m a``,
+and could be represented more concretely by values like ``Nothing``, ``Just x``,
+or ``Right x``. It is important to note that some of these concrete
+instantiations of the value ``m`` have multiple components. In discussing the
+second and third monad laws, we'll see some examples of how this plays out.
+
 The second law states that a monadic value ``m`` passed through ``(>>=)``
 into ``return`` is exactly equivalent to itself. In other words, using bind to
 pass a monadic value to ``return`` does not change the initial value.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1493,9 +1493,9 @@ constructors. The second snippet shows how a value represented by a nullary type
 constructor works within the context of the second law.
 
 ```haskell
-(SomeMonad x) >>= return ≡ SomeMonad x    -- 'SomeMonad x' has type 'm a' just
-                                          -- 'm' from the first example of the
-                                          -- second law
+(SomeMonad val) >>= return ≡ SomeMonad val  -- 'SomeMonad val' has type 'm a' just
+                                            -- 'm' from the first example of the
+                                            -- second law
 
 NullaryMonadType >>= return ≡ NullaryMonadType
 ```
@@ -1515,6 +1515,22 @@ expression passed through ``(>>=)`` to the function ``g``.
                                            -- has type 'm a'. The functions 'f'
                                            -- and 'g' have types '(a -> m b)'
                                            -- and '(b -> m c)' respectively
+```
+
+Again, it is possible to write this law with more explicit code. Like in the
+explict examples for law 2, ``m`` has been replaced by ``SomeMonad val`` in
+order to be very clear that there can be multiple components to a monadic value.
+Although little has changed in the code, it is easier to see what
+value--namely, ``val``--corresponds to the ``x`` in the lambda expression.
+After ``SomeMonad val`` is passed through ``(>>=)`` to ``f``, the function ``f``
+operates on ``val`` and returns a result still wrapped in the ``SomeMonad``
+type constructor. We can call this new value ``SomeMonad newVal``. Since it is
+still wrapped in the monadic context, ``SomeMonad newVal`` can thus be passed
+through the bind operation into the function ``g``.
+
+```haskell
+((SomeMonad val) >>= f) >>= g ≡ (SomeMonad val) >>= (\x -> f x >>= g)
+
 ```
 
 See: [Monad Laws](http://wiki.haskell.org/Monad_laws)

--- a/tutorial.md
+++ b/tutorial.md
@@ -1459,10 +1459,10 @@ Laws
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
 
+**Law 1**
+
 The first law says that when ``return a`` is passed through a ``(>>=)`` into a
 function ``f``, this expression is exactly equivalent to ``f a``.
-
-**Law 1**
 
 ```haskell
 return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
@@ -1475,17 +1475,17 @@ or ``Right x``. It is important to note that some of these concrete
 instantiations of the value ``m`` have multiple components. In discussing the
 second and third monad laws, we'll see some examples of how this plays out.
 
+**Law 2**
+
 The second law states that a monadic value ``m`` passed through ``(>>=)``
 into ``return`` is exactly equivalent to itself. In other words, using bind to
 pass a monadic value to ``return`` does not change the initial value.
-
-**Law 2**
 
 ```haskell
 m >>= return ≡ m        -- 'm' here refers to a value that has type 'm a'
 ```
 
-A more explicit way to write the second Monad law exists.  In this following
+A more explicit way to write the second Monad law exists. In this following
 example code, the first expression shows how the second law applies to values
 represented by
 [non-nullary](https://wiki.haskell.org/Constructor#Type_constructor) type
@@ -1500,6 +1500,8 @@ constructor works within the context of the second law.
 NullaryMonadType >>= return ≡ NullaryMonadType
 ```
 
+**Law 3**
+
 While the first two laws are relatively clear, the third law may be more
 difficult to understand. This law states that when a monadic value ``m`` is
 passed through ``(>>=)`` to the function ``f`` and then the result of that
@@ -1507,8 +1509,6 @@ expression is passed to ``>>= g``, the entire expression is exactly equivalent
 to passing ``m`` to a lamda expression that takes one parameter ``x`` and
 outputs the function ``f`` applied to ``x``, with the resultant value of that
 expression passed through ``(>>=)`` to the function ``g``.
-
-**Law 3**
 
 ```haskell
 (m >>= f) >>= g ≡ m >>= (\x -> f x >>= g)  -- Like in the last law, 'm' has

--- a/tutorial.md
+++ b/tutorial.md
@@ -1414,18 +1414,23 @@ Laws
 ----
 
 Monads are not complicated. They are implemented as a typeclass with two
-functions, ``(>>=)`` (pronounced "bind") and ``return``. Any preconceptions one
-might have for the word "return" should be discarded: It has an entirely
-different meaning in the context of Haskell. The following code snippet
-describes the arity of the functions required by the Monad typeclass.
+functions, ``return`` and ``(>>=)`` (pronounced "bind"). In order to implement
+a Monad instance, these two functions must be defined in accordance with arity
+described in the typeclass definition:
 
 ```haskell
 class Monad m where
   (>>=)  :: m a -> (a -> m b) -> m b
   return :: a -> m a                     -- N.B. 'm' refers to a higher-kinded  type
                                          -- (e.g., Maybe, List, Either, etc.) that
-                                         -- implements the Monad typeclass.
 ```
+
+Any preconceptions one might have for the word "return" should be discarded:
+It has an entirely different meaning in the context of Haskell. The ``return``
+function acts very differently than in languages like C, Python, or Java.
+Instead of being the final arbiter of what value a function
+produces, ``return`` in Haskell injects a value of type ``a`` into a monadic
+context (e.g., Maybe, Either, etc.).
 
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
@@ -1438,7 +1443,6 @@ function ``f``, this expression is exactly equivalent to ``f a``.
 ```haskell
 return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
 ```
-
 
 **Law 2**
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1422,13 +1422,15 @@ describes the arity of the functions required by the Monad typeclass.
 ```haskell
 class Monad m where
   (>>=)  :: m a -> (a -> m b) -> m b
-  return :: a -> m a
+  return :: a -> m a                     -- N.B. 'm' refers to a higher-kinded  type
+                                         -- (e.g., Maybe, List, Either, etc.) that
+                                         -- implements the Monad typeclass.
 ```
 
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
 
-The first law says that when ``return a`` is passed through a ``bind`` into a
+The first law says that when ``return a`` is passed through a ``(>>=)`` into a
 function ``f``, this expression is exactly equivalent to ``f a``.
 
 **Law 1**
@@ -1436,6 +1438,7 @@ function ``f``, this expression is exactly equivalent to ``f a``.
 ```haskell
 return a >>= f ≡ f a    -- N.B. 'a' refers to a value, not a type
 ```
+
 
 **Law 2**
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1388,7 +1388,7 @@ Instead, I suggest a path to enlightenment:
 8. Don't write monad-analogy tutorials.
 
 In other words, the only path to understanding monads is to read the fine
-source, fire up GHC and write some code. Analogies and metaphors will not lead
+source, fire up GHC, and write some code. Analogies and metaphors will not lead
 to understanding.
 
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1415,8 +1415,8 @@ Laws
 
 Monads are not complicated, the implementation is a typeclass with two
 functions, ``(>>=)`` pronounced "bind" and ``return``. Any preconceptions one
-might have for the word "return" should be discarded, it has an entirely
-different meaning.
+might have for the word "return" should be discarded: It has an entirely
+different meaning in the context of Haskell.
 
 ```haskell
 class Monad m where

--- a/tutorial.md
+++ b/tutorial.md
@@ -1410,7 +1410,7 @@ The following are all **false**:
 
 See: [What a Monad Is Not](http://wiki.haskell.org/What_a_Monad_is_not)
 
-Laws
+Monadic Methods
 ---------------
 
 Monads are not complicated. They are implemented as a typeclass with two
@@ -1442,6 +1442,9 @@ operation results in a final value of type ``m b``.
 
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
+
+Laws
+----
 
 The first law says that when ``return a`` is passed through a ``(>>=)`` into a
 function ``f``, this expression is exactly equivalent to ``f a``.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1448,6 +1448,11 @@ that discards its argument.
 m >> k = m >>= \_ -> k
 ```
 
+This definition says that (>>) has a left and right argument which are monadic
+with types ``m a`` and ``m b`` respectively, while the infix returns a value of
+type ``m b``.  The actual implementation of (>>) says that when ``m`` is passed
+to ``(>>)`` with ``k`` on the right, the value ``k`` will always be returned.
+
 Laws
 ----
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1428,6 +1428,9 @@ class Monad m where
 In addition to specific implementations of ``(>>=)`` and ``return``, all monad
 instance must satisfy three laws.
 
+The first law says that when ``return a`` is passed through a ``bind`` into a
+function ``f``, this expression is exactly equivalent to ``f a``.
+
 **Law 1**
 
 ```haskell

--- a/tutorial.md
+++ b/tutorial.md
@@ -1475,7 +1475,7 @@ pass a monadic value to ``return`` does not change the initial value.
 **Law 2**
 
 ```haskell
-m >>= return ≡ m
+m >>= return ≡ m        -- 'm' here refers to a value that has type 'm a'
 ```
 
 **Law 3**

--- a/tutorial.md
+++ b/tutorial.md
@@ -1420,12 +1420,14 @@ described in the typeclass definition:
 
 ```haskell
 class Monad m where
-  (>>=)  :: m a -> (a -> m b) -> m b
   return :: a -> m a                     -- N.B. 'm' refers to a type constructor
                                          -- (e.g., Maybe, Either, etc.) that
                                          -- implements the Monad typeclass
+
+  (>>=)  :: m a -> (a -> m b) -> m b
 ```
 
+The first type signature in the Monad class definition is for ``return``.
 Any preconceptions one might have for the word "return" should be discarded:
 It has an entirely different meaning in the context of Haskell. The ``return``
 function acts very differently than in languages like C, Python, or Java.

--- a/tutorial.md
+++ b/tutorial.md
@@ -1411,7 +1411,7 @@ The following are all **false**:
 See: [What a Monad Is Not](http://wiki.haskell.org/What_a_Monad_is_not)
 
 Laws
-----
+---------------
 
 Monads are not complicated. They are implemented as a typeclass with two
 functions, ``return`` and ``(>>=)`` (pronounced "bind"). In order to implement
@@ -1429,11 +1429,11 @@ class Monad m where
 
 The first type signature in the Monad class definition is for ``return``.
 Any preconceptions one might have for the word "return" should be discarded:
-It has an entirely different meaning in the context of Haskell. The ``return``
-function acts very differently than in languages like C, Python, or Java.
-Instead of being the final arbiter of what value a function
-produces, ``return`` in Haskell injects a value of type ``a`` into a monadic
-context (e.g., Maybe, Either, etc.).
+It has an entirely different meaning in the context of Haskell and acts very
+differently than in languages like C, Python, or Java. Instead of being the
+final arbiter of what value a function produces, ``return`` in Haskell injects a
+value of type ``a`` into a monadic context (e.g., Maybe, Either, etc.), which is
+denoted as ``m a``.
 
 The other function essential to implementing a Monad instance is ``(>>=)``.
 This infix takes two arguments. On its left side is a value with type ``m a``,

--- a/tutorial.md
+++ b/tutorial.md
@@ -1416,7 +1416,8 @@ Laws
 Monads are not complicated. They are implemented as a typeclass with two
 functions, ``(>>=)`` (pronounced "bind") and ``return``. Any preconceptions one
 might have for the word "return" should be discarded: It has an entirely
-different meaning in the context of Haskell.
+different meaning in the context of Haskell. The following code snippet
+describes the arity of the functions required by the Monad typeclass.
 
 ```haskell
 class Monad m where


### PR DESCRIPTION
These edits are somewhat more extensive than the previous batch. Most of the really large changes come in the Laws section. First, I broke up the Laws section into two. The new section is 'Monadic Methods', which attempts to explicate return and bind for less experienced readers.

I have also expanded the Laws section quite a bit by adding prose versions of the laws, as well as supplemental code that is (hopefully) a bit more explicit than the normal way the Laws are written. I freely admit that the section may be ridiculously explicit for more experienced Haskellers. Hopefully these explanations are not too convoluted or burdensome to the reader.

Turns out, Monads are kind of hard to write about clearly, lol.