### PR TITLE
Add section on atom editor to Editor Integrations

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -824,6 +824,12 @@ implement features common to modern IDEs.
 * [Haskell Development From Emacs](http://tim.dysinger.net/posts/2014-02-18-haskell-with-emacs.html)
 * [Structured Haskell Mode](https://github.com/chrisdone/structured-haskell-mode)
 
+**Atom**
+* [language-haskell plugin](https://atom.io/packages/language-haskell)
+* [ide-haskell plugin](https://atom.io/packages/ide-haskell)
+
+
+
 Bottoms
 -------
 


### PR DESCRIPTION
Hello,

I am a long-time Emacs user but a recent bout of emacs-pinky sent me off to the [Atom editor](https://atom.io). While using this editor, I was surprised and pleased to discover excellent Haskell integration via the `ide-haskell` plugin and friends, which integrate really well with `ghc-mod`.

It seemed strong enough to me to be worthy of inclusion in the *Editor Integrations* section of the tutorial,  and because that resource is so widely disseminated, I thought it might be possible that it would reach people who are already using the Atom editor. 

Also want to say thanks for providing this resource.