### PR TITLE
Merge material from partial types extension section with type hole section

### DIFF
--- a/src/01-basics/typedhole.hs
+++ b/src/01-basics/typedhole.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS -XPartialTypeSignatures #-}
+
+head' = head _
+
+const' :: _
+const' x y = x
+
+foo :: _a -> _a
+foo _ = False
+
+succ' :: _ => a -> a
+succ' x = x + 1
+
+main = undefined

--- a/src/04-extensions/README.md
+++ b/src/04-extensions/README.md
@@ -8,5 +8,6 @@ $ stack exec ghci patterns.hs
 $ stack exec ghci safe.hs
 $ stack exec ghci views.hs
 $ stack exec ghci wildcards.hs
+$ stack exec ghci monomorphism.hs
 $ stack exec ghci wildcards_update.hs
 ```

--- a/src/04-extensions/monomorphism.hs
+++ b/src/04-extensions/monomorphism.hs
@@ -1,9 +1,18 @@
--- Double is inferred by type inferencer.
-example1 :: Double
-example1 = 3.14
+{-# LANGUAGE NoMonomorphismRestriction #-}
 
--- In the presense of a lambda, a different type is inferred!
-example2 :: Fractional a => t -> a
-example2 _ = 3.14
+module Monomorphism (foo,bar) where
 
-default (Integer, Double)
+-- + extension: Num a => a -> a -> a
+-- - extension: Num a => a -> a -> a
+foo x y = x + y
+
+-- + extension: Num a => a -> a
+-- - extension: Integer -> Integer 
+bar = foo 1
+
+
+-- Now if this module is loaded without the extension,
+-- then the call `bar 1.0` fails, since 1.0 is not a valid
+-- Integer. If, however, `bar 1.0` was called somewhere within
+-- this module, then there would be enough information to
+-- correctly infer the type.

--- a/src/04-extensions/partial_type_signatures.hs
+++ b/src/04-extensions/partial_type_signatures.hs
@@ -1,0 +1,6 @@
+{-# OPTIONS -XPartialTypeSignatures #-}
+
+triple :: Int -> _
+triple i = (i,i,i)
+
+main = undefined

--- a/tutorial.md
+++ b/tutorial.md
@@ -2712,6 +2712,7 @@ problems. These include:
 These almost always indicate a design flaw and shouldn't be turned on to remedy the error at hand, as
 much as GHC might suggest otherwise!
 
+
 NoMonomorphismRestriction
 -------------------------
 
@@ -2764,15 +2765,16 @@ Now everything will work as expected:
 bar :: Num a => a -> a
 ```
 
-Extended Defaulting
--------------------
+ExtendedDefaultRules
+--------------------
 
-Haskell normally applies several defaulting rules for ambiguous literals in the
-absence of an explicit type signature. When an ambiguous literal is typechecked,
-if at least one of its typeclass constraints is numeric and all of its classes
-are standard library classes, the module's default list is consulted, and the
-first type from the list that will satisfy the context of the type variable is
-instantiated. So for instance given the following default rules.
+In the absence of explicit type signatures, Haskell normally resolves ambiguous
+literals using several defaulting rules. When an ambiguous literal is
+typechecked, if at least one of its typeclass constraints is numeric and all of
+its classes are standard library classes, the module's default list is
+consulted, and the first type from the list that will satisfy the context of
+the type variable is instantiated. So for instance, given the following default
+rules
 
 ```haskell
 default (C1 a,...,Cn a)
@@ -2781,17 +2783,17 @@ default (C1 a,...,Cn a)
 The following set of heuristics is used to determine what to instantiate the
 ambiguous type variable to.
 
-1. The type variable a appears in no other constraints
-1. All the classes Ci are standard.
-1. At least one of the classes Ci is numeric.
+1. The type variable ``a`` appears in no other constraints
+1. All the classes ``Ci`` are standard.
+1. At least one of the classes ``Ci`` is numeric.
 
-The default default is (Integer, Double)
+The default ``default`` is ``(Integer, Double)``
 
 This is normally fine, but sometimes we'd like more granular control over
 defaulting. The ``-XExtendedDefaultRules`` loosens the restriction that we're
 constrained with working on Numerical typeclasses and the constraint that we can
 only work with standard library classes. If we'd like to have our string
-literals (using -XOverlodaedStrings) automatically default to the more
+literals (using ``-XOverloadedStrings``) automatically default to the more
 efficient ``Text`` implementation instead of ``String`` we can twiddle the flag
 and GHC will perform the right substitution without the need for an explicit
 annotation on every string literal.
@@ -2807,13 +2809,13 @@ default (T.Text)
 example = "foo"
 ```
 
-For code typed at the GHCi prompt, the `-XExtendedDefaultRules` flag is always
+For code typed at the GHCi prompt, the ``-XExtendedDefaultRules`` flag is always
 on, and cannot be switched off.
 
 See: [Monomorphism Restriction](#monomorphism-restriction)
 
-Safe Haskell
-------------
+Safe
+----
 
 As everyone eventually finds out there are several functions within the
 implementation of GHC ( not the Haskell language ) that can be used to subvert
@@ -2855,8 +2857,9 @@ The module itself isn't safe.
 
 See: [Safe Haskell](https://ghc.haskell.org/trac/ghc/wiki/SafeHaskell)
 
-Partial Type Signatures
------------------------
+
+PartialTypeSignatures
+---------------------
 
 Normally a function is either given a full explicit type signature or none at
 all. The partial type signature extension allows something in between.
@@ -2876,13 +2879,14 @@ trigger warnings.
 
 See: [Partial Type Signatures](https://ghc.haskell.org/trac/ghc/wiki/PartialTypeSignatures)
 
-Recursive Do
-------------
 
-Recursive do notation allows to use to self-reference expressions on both sides
-of a monadic bind. For instance the following uses lazy evaluation to generate a
-infinite list. This is sometimes used for instantiating cyclic datatypes inside
-of a monadic context that need to hold a reference to themselves.
+RecursiveDo
+-----------
+
+Recursive do notation allows use of self-reference expressions on both sides of
+a monadic bind. For instance the following uses lazy evaluation to generate
+an infinite list. This is sometimes used to instantiate a cyclic datatype
+inside a monadic context that needs to hold a reference to itself.
 
 ```haskell
 {-# LANGUAGE RecursiveDo #-}
@@ -2895,8 +2899,8 @@ justOnes = do
 
 See: [Recursive Do Notation](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#the-recursive-do-notation)
 
-Applicative Do
---------------
+ApplicativeDo
+-------------
 
 By default GHC desugars do-notation to use implicit invocations of bind and
 return.
@@ -2929,8 +2933,8 @@ test :: Applicative m => m (a, b, c)
 test = (,,) <$> f <*> g <*> h
 ```
 
-Pattern Guards
---------------
+PatternGuards
+-------------
 
 Pattern guards are an extension to the pattern matching syntax.  Given a ``<-``
 pattern qualifier, the right hand side is evaluated and matched against the
@@ -2978,12 +2982,12 @@ f = (,(),,(),(),,)
 ```
 
 MultiWayIf
-------------
+----------
 
-Multi-way expands traditional if statements to allow pattern match conditions
-that are equivalent to a chain of if-then-else statements. This allows us to
-write "pattern matching predicates" on a value. This alters the syntax of
-Haskell language.
+Multi-way if expands traditional if statements to allow pattern match
+conditions that are equivalent to a chain of if-then-else statements. This
+allows us to write "pattern matching predicates" on a value. This alters the
+syntax of Haskell language.
 
 ```haskell
 {-# LANGUAGE MultiWayIf #-}
@@ -2992,12 +2996,12 @@ bmiTell :: Float -> Text
 bmiTell bmi = if
   | bmi <= 18.5 -> "Underweight."
   | bmi <= 25.0 -> "Average weight."
-  | bmi <= 30.0 -> "Overewight."
+  | bmi <= 30.0 -> "Overweight."
   | otherwise   -> "Clinically overweight."
 ```
 
 EmptyCase
--------------
+---------
 
 GHC normally requires at least one pattern branch in case statement this
 restriction can be relaxed with -XEmptyCase. The case statement then immediately
@@ -3008,7 +3012,7 @@ test = case of
 ```
 
 LambdaCase
--------------
+----------
 
 For case statements, LambdaCase allows the elimination of redundant free
 variables introduced purely for the case of pattern matching on.
@@ -3147,30 +3151,30 @@ DeriveFunctor
 ~~~~
 
 DeriveTraversable
--------------
+-----------------
 
 ~~~~ {.haskell include="src/04-extensions/derive_traversable.hs"}
 ~~~~
 
 DeriveFoldable
--------------
+--------------
 
 DeriveGeneric
 -------------
 
 DeriveAnyClass
--------------
+--------------
 
-With ``-XDeriveAnyClass`` we can derive any class. The deriving logic s
-generates an instance declaration for the type with no explicitly-defined
-methods.  If the typeclass implements a default for each method then this will
-be well-defined and give rise to an automatic instances.
+With ``-XDeriveAnyClass`` we can derive any class. The deriving logic generates
+an instance declaration for the type with no explicitly-defined methods. If
+the typeclass implements a default for each method then this will be
+well-defined and give rise to an automatic instances.
 
 StaticPointers
 --------------
 
 DuplicateRecordFields
-----------------------
+---------------------
 
 GHC 8.0 introduced the ``DuplicateRecordFields`` extensions which loosens GHC's
 restriction on records in the same module with identical accessors. The precise
@@ -3236,7 +3240,7 @@ See:
 
 * [OverloadedRecordFields revived](http://www.well-typed.com/blog/2015/03/overloadedrecordfields-revived/)
 
-Cpp
+CPP
 ---
 
 The C++ preprocessor is the fallback whenever we really need to separate out

--- a/tutorial.md
+++ b/tutorial.md
@@ -1281,6 +1281,9 @@ it :: Num a => a
 it :: Num a => a
 ```
 
+This rule my be deactivated with the ``NoMonomorphicRestriction`` extension,
+see [below](#nomonomorphicrestriction).
+
 See: [Monomorphism Restriction](https://wiki.haskell.org/Monomorphism_restriction)
 
 
@@ -2708,6 +2711,58 @@ problems. These include:
 
 These almost always indicate a design flaw and shouldn't be turned on to remedy the error at hand, as
 much as GHC might suggest otherwise!
+
+NoMonomorphismRestriction
+-------------------------
+
+The NoMonomorphismRestriction allows us to disable the monomorphism restriction
+typing rule GHC uses by default. See [monomorphism
+restriction](#monomorphism-restriction).
+
+For example, if we load the following module into GHCi
+
+```haskell
+module Bad (foo,bar) where
+foo x y = x + y
+bar = foo 1
+```
+
+and then we attempt to call the function ``bar`` with a Double, we get a type
+error:
+
+```bash
+λ: bar 1.1
+<interactive>:2:5: error:
+    • No instance for (Fractional Integer)
+      arising from the literal ‘1.0’
+    • In the first argument of ‘bar’, namely ‘1.0’
+      In the expression: bar 1.0
+      In an equation for ‘it’: it = bar 1.0
+```
+
+The problem is that GHC has inferred an overly specific type:
+
+```bash
+λ: :t bar
+bar :: Integer -> Integer
+```
+
+We can prevent GHC from specializing the type with this extension, i.e.
+
+```haskell
+{-# LANGUAGE NoMonomorphismRestriction #-}
+
+module Good (foo,bar) where
+foo x y = x + y
+bar = foo 1
+```
+
+Now everything will work as expected:
+
+```bash
+λ: :t bar
+bar :: Num a => a -> a
+```
 
 Extended Defaulting
 -------------------

--- a/tutorial.md
+++ b/tutorial.md
@@ -637,10 +637,10 @@ integrate with the ``cabal`` build system. These packages are often left
 undocumented as well.
 
 For developers coming to Haskell from other language ecosystems that favor
-the former philsophy (e.g., Python, Javascript, Ruby), seeing  *thousands of
+the former philosophy (e.g., Python, Javascript, Ruby), seeing  *thousands of
 libraries without the slightest hint of documentation or description of purpose*
 can be unnerving. It is an open question whether the current cultural state of
-Hackage is sustainable in light of these philsophical differences.
+Hackage is sustainable in light of these philosophical differences.
 
 Needless to say, there is a lot of very low-quality Haskell code and
 documentation out there today, so being conservative in library assessment is a
@@ -1037,7 +1037,7 @@ within that function is *non-exhaustive*. In other words, the function does not
 implement appropriate handling of all valid inputs. Instead of yielding a value,
 such a function will halt from an incomplete match.
 
-Partial functions from non-exhaustivity are a controversial subject, and
+Partial functions from non-exhaustively are a controversial subject, and
 frequent use of non-exhaustive patterns is considered a dangerous code smell.
 However, the complete removal of non-exhaustive patterns from the language
 would itself be too restrictive and forbid too many valid programs.
@@ -1190,7 +1190,7 @@ Type Holes / Pattern Wildcards
 ------------------------------
 
 Since the release of GHC 7.8, type holes, or pattern wildcards, allow
-underscores as standins for actual values. They may be used either in
+underscores as stand-ins for actual values. They may be used either in
 declarations or in type signatures.
 
 Type holes are useful in debugging of incomplete programs. By placing an
@@ -1903,7 +1903,7 @@ many things, including, but not limited to:
  - Read and parse input from the terminal
  - Read from or write to a file on the system
  - Establish an ``ssh`` connection to a remote computer
- - Take input from a radio antenna for singal processing
+ - Take input from a radio antenna for signal processing
 
 Conceptualizing I/O as a monad enables the developer to access information
 outside the program, but operate on the data with pure functions. The following
@@ -1959,7 +1959,7 @@ main = do putStrLn "What is your name: "
 ```
 
 The next code block is the desugared equivalent of the previous example;
-however, the uses of ``(>>=)`` are made explict.
+however, the uses of ``(>>=)`` are made explicit.
 
 ```haskell
 main :: IO ()
@@ -1970,7 +1970,7 @@ main = putStrLn "What is your name:" >>=
 
 Our final example executes in the same way as the previous two examples. This
 example, though, uses the special ``(>>)`` [operator](#monadic-methods) to take
-the place of binding a result to the lamda that discards its argument.
+the place of binding a result to the lambda that discards its argument.
 
 ```haskell
 main :: IO ()
@@ -2708,7 +2708,7 @@ it :: Num a => a
 Extended Defaulting
 -------------------
 
-Haskell normally applies several defaulting rules for ambigious literals in the
+Haskell normally applies several defaulting rules for ambiguous literals in the
 absence of an explicit type signature. When an ambiguous literal is typechecked
 if at least one of its typeclass constraints is numeric and all of its classes
 are standard library classes, the module's default list is consulted, and the
@@ -2719,7 +2719,7 @@ instantiated. So for instance given the following default rules.
 default (C1 a,...,Cn a)
 ```
 
-The following set of heuristics is used to determine what to instnatiate the
+The following set of heuristics is used to determine what to instantiate the
 ambiguous type variable to.
 
 1. The type variable a appears in no other constraints
@@ -2977,7 +2977,7 @@ NumDecimals
 -----------
 
 NumDecimals allows the use of exponential notation for integral literals that
-are not necessarily floats. Without it, any use of expontial notation
+are not necessarily floats. Without it, any use of exponential notation
 induces a Fractional class constraint.
 
 ```haskell
@@ -3142,9 +3142,9 @@ OverloadedLabels
 GHC 8.0 also introduced the OverloadedLabels extension which allows a limited
 form of polymorphism over labels that share the same name.
 
-To work with overloaded labels types we need to enable several language
-extensions to work with promoted strings and multiparam typeclasses that underly
-it's implementation.
+To work with overloaded label types we need to enable several language
+extensions to work with promoted strings and multiparam typeclasses that
+underlay it's implementation.
 
 ```haskell
 extract :: IsLabel "id" t => t
@@ -6994,7 +6994,7 @@ e = Proxy
 In cases where we'd normally pass around a ``undefined`` as a witness of a
 typeclass dictionary, we can instead pass a Proxy object which carries the
 phantom type without the need for the bottom. Using scoped type variables we can
-then operate with the phantom paramater and manipulate wherever is needed.
+then operate with the phantom parameter and manipulate wherever is needed.
 
 ```haskell
 t1 :: a
@@ -7366,10 +7366,10 @@ Liquid Haskell
 LiquidHaskell is not typically necessary to write Haskell.
 </div>
 
-LiquidHaskell is an extension to GHC's typesystem that adds the capactity for
+LiquidHaskell is an extension to GHC's typesystem that adds the capacity for
 refinement types using the annotation syntax. The type signatures of functions
 can be checked by the external for richer type semantics than default GHC
-provides, including non-exhaustive patterns and complex arithemtic properties
+provides, including non-exhaustive patterns and complex arithmetic properties
 that require external SMT solvers to verify. For instance LiquidHaskell can
 statically verify that a function that operates over a ``Maybe a`` is always
 given a ``Just`` or that an arithmetic functions always yields an Int that is
@@ -8020,7 +8020,7 @@ Haskell supports arithmetic with complex numbers via a Complex datatype from the
 ``Data.Complex`` module. The first argument is the real part, while the second
 is the imaginary part. The type has a single parameter and inherits it's
 numerical typeclass components (Num, Fractional, Floating) from the type of this
-paramater.
+parameter.
 
 ```haskell
 -- 1 + 2i
@@ -8817,7 +8817,7 @@ in parallel.
 The functions above are quite useful, but will break down if evaluation of the arguments needs to be
 parallelized beyond simply weak head normal form. For instance if the arguments to ``rpar`` is a nested
 constructor we'd like to parallelize the entire section of work in evaluated the expression to normal form
-instead of just the outer layer. As such we'd like to generalize our strategies so the the evaluation strategy
+instead of just the outer layer. As such we'd like to generalize our strategies so the evaluation strategy
 for the arguments can be passed as an argument to the strategy.
 
 ``Control.Parallel.Strategies`` contains a generalized version of ``rpar`` which embeds additional evaluation
@@ -8834,7 +8834,7 @@ rdeepseq :: NFData a => Strategy a
 rdeepseq x = rseq (force x)
 ```
 
-We now can create a "higher order" strategy that takes two strategies and itself yields a a computation which
+We now can create a "higher order" strategy that takes two strategies and itself yields a computation which
 when evaluated uses the passed strategies in its scheduling.
 
 ~~~~ {.haskell include="src/22-concurrency/strategies_param.hs"}
@@ -8928,7 +8928,7 @@ Graphics
 Diagrams
 --------
 
-Diagrams is a a parser combinator library for generating vector images to SVG and a variety of other formats.
+Diagrams is a parser combinator library for generating vector images to SVG and a variety of other formats.
 
 ~~~~ {.haskell include="src/23-graphics/diagrams.hs"}
 ~~~~
@@ -9107,7 +9107,7 @@ Optparse Applicative
 --------------------
 
 Optparse-applicative is a combinator library for building command line
-interfaces that take in various user flags, commmands and switches and map them
+interfaces that take in various user flags, commands and switches and map them
 into Haskell data structures that can handle the input. The main interface is
 through the applicative functor ``Parser`` and various combinators such as
 ``strArgument`` and ``flag`` which populate the option parsing table with some
@@ -9959,7 +9959,7 @@ execute_ :: Connection -> Query -> IO Int64
 ```
 
 The result of the ``query`` function is a list of elements which implement the
-FromRow typeclass. This can be many things including a single elemment (Only), a
+FromRow typeclass. This can be many things including a single element (Only), a
 list of tuples where each element implements ``FromField`` or a custom datatype
 that itself implements ``FromRow``. Under the hood the database bindings
 inspects the Postgres ``oid`` objects and then attempts to convert them into the
@@ -12483,9 +12483,9 @@ In a separate module we can then enable Quasiquotes and embed the string.
 git-embed
 ----------
 
-Often times it is neccessary to embed the specific Git version hash of a build
-inside the exectuable. Using git-embed the compiler will effectivelly shell out
-to the command line to retrieve the version information of the CWD Git repostory
+Often times it is necessary to embed the specific Git version hash of a build
+inside the executable. Using git-embed the compiler will effectively shell out
+to the command line to retrieve the version information of the CWD Git repository
 and use Template Haskell to define embed this information at compile-time. This
 is often useful for embedding in ``--version`` information in the command line
 interface to your program or service.
@@ -12956,7 +12956,7 @@ enforce purity and uses call-by-value.
 OCaml's main implementation is [*ocamlc*](http://ocaml.org/). The OCaml compiler
 is distributed under [the Q Public
 licence](http://www.gnu.org/licenses/license-list.html#QPL), a permissive,
-non-copyleft FLOSS licence. Some portions of the OCaml libaries are licensed under
+non-copyleft FLOSS licence. Some portions of the OCaml libraries are licensed under
 the [GPLv2](http://www.gnu.org/licenses/gpl.html). See the [OCaml GitHub
 page](https://github.com/ocaml/ocaml/blob/trunk/LICENSE) for more information
 about licensing specifics.
@@ -13516,7 +13516,7 @@ The majority of Javascript implementations are garbage collected.
 Kotlin
 ------
 
-**Main difference**: Kotlin is an imperative langauge which structures code
+**Main difference**: Kotlin is an imperative language which structures code
 around objects and classes, compared to Haskell which is functional language
 emphasizing pure higher-order functions.
 
@@ -13544,7 +13544,7 @@ PHP
 PHP is a high-level, dynamic, untyped, and interpreted programming language that
 was common for scripting web applications in the 00s. PHP is widely criticized
 for it's poor design, unsafe defaults, and improper handling of simple
-programming constructs. Nevertheless PHP is widely used as the backet for
+programming constructs. Nevertheless, PHP is widely used as the backend for
 several of the highest profile websites.
 
 **Main difference**: PHP was designed in ad-hoc fashion to meet the needs of


### PR DESCRIPTION
I am very new in Haskell and am learning a lot from this document, many thanks!

There was a little discontinuity in the `extensions` section. The part on the `PartialTypeSignatures` extension begins with the phrase

```
The same hole technique can be applied at the toplevel for signatures:
```

Which is a reference way back to the type holes entry in the `basics` section. I moved most of the material on partial type signatures to the basics section and left the discussion specific to the extension in the extension section.

In a second commit, I also fixed some typos.

I hope this is helpful, and thanks again for your work.