### PR TITLE
Remove information that Erlang is interpreted

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -13298,8 +13298,6 @@ Erlang's main implementation is *erl*.
 
 Erlang is a *unityped* language.
 
-Erlang is interpreted.
-
 Erlang allows polymorphism by means of *unityping*.
 
 Erlang's evaluation is *call-by-value*.


### PR DESCRIPTION
While it can act as an interpreted languaged (via escript), normally it is compiled.

It can be also debated [whether Erlang should be called imperative, not functional](https://stackoverflow.com/questions/2271417/is-erlang-really-a-functional-language).