### PR TITLE
Remove extra words from Diagrams description

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -8992,7 +8992,7 @@ Graphics
 Diagrams
 --------
 
-Diagrams is a parser combinator library for generating vector images to SVG and a variety of other formats.
+Diagrams is a library for generating vector images to SVG and a variety of other formats.
 
 ~~~~ {.haskell include="src/23-graphics/diagrams.hs"}
 ~~~~


### PR DESCRIPTION
I could be mistaken, but it looks like the bit about "parser combinator" crept in from the next section on Parsec.