### PR TITLE
Fixing version in title

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1,4 +1,4 @@
-% What I Wish I Knew When Learning Haskell (Version 2.3)
+% What I Wish I Knew When Learning Haskell (Version 2.4)
 % Stephen Diehl
 % March 2016
 


### PR DESCRIPTION
I didn't change the date, because I couldn't find exactly when the rollover in versions happened.