### PR TITLE
Fix code not sitting next to error msg in Newtype Deriving

### DIFF
--- a/src/03-monad-transformers/newtype.hs
+++ b/src/03-monad-transformers/newtype.hs
@@ -1,5 +1,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+newtype Quantity v a = Quantity a
+  deriving (Eq, Ord, Num, Show)
+
+data Haskeller
+type Haskellers = Quantity Haskeller Int
+
+a = Quantity 2 :: Haskellers
+b = Quantity 6 :: Haskellers
+
+totalHaskellers :: Haskellers
+totalHaskellers = a + b
+
 newtype Velocity = Velocity { unVelocity :: Double }
   deriving (Eq, Ord)
 
@@ -12,15 +24,3 @@ x = 2.718
 -- Type error is caught at compile time even though
 -- they are the same value at runtime!
 err = v + x
-
-newtype Quantity v a = Quantity a
-  deriving (Eq, Ord, Num, Show)
-
-data Haskeller
-type Haskellers = Quantity Haskeller Int
-
-a = Quantity 2 :: Haskellers
-b = Quantity 6 :: Haskellers
-
-totalHaskellers :: Haskellers
-totalHaskellers = a + b


### PR DESCRIPTION
Move Velocity newtype code down to sit directly above the pertinent type mismatch error comment.