### PR TITLE
Replace `allDifferent` by `distinct`

### DIFF
--- a/src/19-numbers/puzzle.hs
+++ b/src/19-numbers/puzzle.hs
@@ -8,7 +8,7 @@ val = foldr1 (\d r -> d + 10*r) . reverse
 puzzle :: Symbolic SBool
 puzzle = do
   ds@[b,u,r,i,t,o,m,n,a,d] <- sequenceA [ sInteger [v] | v <- "buritomnad" ]
-  constrain $ allDifferent ds
+  constrain $ distinct ds
   for_ ds $ \d -> constrain $ inRange d (0,9)
   pure $    val [b,u,r,r,i,t,o]
           + val     [m,o,n,a,d]


### PR DESCRIPTION
According to SBV's change log (https://github.com/LeventErkok/sbv/blob/master/CHANGES.md), `allDifferent` has been replaced by `distinct`.