### PR TITLE
Fix parse error in haddock multiline comments

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -1460,7 +1460,7 @@ Multiline comments are also possible:
 ```haskell
 -- | Multiline documentation for the function
 -- f with multiple arguments.
-fmap :: Functor f =>
+fmap :: Functor f
      => (a -> b)  -- ^ function
      -> f a       -- ^ input
      -> f b       -- ^ output


### PR DESCRIPTION
The `=>` symbol was duplicated so I decided to keep the one at the start of line to be consistent with the subsequent data declaration example where the `=` is also at the start of line.