### PR TITLE
Fixing missing unicode characters in rendered PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IFORMAT = markdown
 TEMPLATE = resources/page.tmpl
 LTEMPLATE = resources/page.latex
 ETEMPLATE = resources/page.epubt
+UNICODE_MAP = resources/unicodemapping.tex
 FLAGS = --standalone \
 				--toc \
 				--toc-depth=2 \
@@ -12,10 +13,11 @@ FLAGS = --standalone \
 GHC=ghc
 
 HTML = tutorial.html
+PDF = tutorial.pdf
 
 # Check if sandbox exists. If it does, then use it instead.
 
-all: $(HTML)
+all: $(HTML) $(PDF)
 
 includes: includes.hs
 	$(GHC) --make $< ; \
@@ -30,14 +32,14 @@ includes: includes.hs
 	| $(PANDOC) -f $(IFORMAT) -t epub $(FLAGS) -o $@
 
 %.pdf: %.md includes
-	./includes < $< | $(PANDOC) -c -s -f $(IFORMAT) --template $(LTEMPLATE) --latex-engine=xelatex $(FLAGS) -o $@
+	./includes < $< | $(PANDOC) -c -s -f $(IFORMAT) --template $(LTEMPLATE) --include-in-header $(UNICODE_MAP) --pdf-engine=xelatex $(FLAGS) -o $@
 
 clean:
-	-rm $(CHAPTERS) $(HTML)
+	-rm $(CHAPTERS) $(HTML) $(PDF)
 
 # pandoc executable 'includes' is rather large
 clean-all:
-	rm -rf $(CHAPTERS) $(HTML) includes
+	rm -rf $(CHAPTERS) $(HTML) $(PDF) includes
 
 # NIX BUILD
 # Enter nix shell with 'make run-shell' first (then 'make all')

--- a/resources/page.latex
+++ b/resources/page.latex
@@ -11,7 +11,6 @@ $if(linestretch)$
 $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}
@@ -25,6 +24,7 @@ $endif$
     \usepackage{fontspec}
   \fi
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+  \setmonofont{DejaVu Sans Mono}
 $if(euro)$
   \newcommand{\euro}{€}
 $endif$

--- a/resources/unicodemapping.tex
+++ b/resources/unicodemapping.tex
@@ -1,0 +1,14 @@
+\newcommand{\sbullet}{%
+  \texorpdfstring{\textsbullet}{\textbullet}%
+}
+\DeclareRobustCommand{\textsbullet}{%
+  \unskip~\,\begin{picture}(1,1)(0,-3)\circle*{3}\end{picture}\ %
+}
+\usepackage{newunicodechar}
+\newunicodechar{⊥}{\ensuremath{\bot}}
+\newunicodechar{⊤}{\ensuremath{\top}}
+\newunicodechar{∨}{\ensuremath{\vee}}
+\newunicodechar{∧}{\ensuremath{\wedge}}
+\newunicodechar{⇒}{\ensuremath{\Rightarrow}}
+\newunicodechar{•}{\ensuremath{\sbullet}}
+\newunicodechar{λ}{\ensuremath{\lambda}}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, compiler ? "ghc865" }: with pkgs;
+{ pkgs ? import <nixpkgs> {}, compiler ? "ghc843" }: with pkgs;
 let
   ghcWithDeps = pkgs.haskell.packages.${compiler}.ghcWithPackages
     ( ps: with ps; [ base pandoc containers ] );

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
-{ nixpkgs ? <nixpkgs>, compiler ? "ghc843" }:
+{ pkgs ? import <nixpkgs> {}, compiler ? "ghc865" }: with pkgs;
 let
-  pkgs = import nixpkgs { };
   ghcWithDeps = pkgs.haskell.packages.${compiler}.ghcWithPackages
     ( ps: with ps; [ base pandoc containers ] );
   tex = with pkgs; texlive.combine {
@@ -9,10 +8,14 @@ let
       xetex
       ;
   };
+  fontsConf = makeFontsConf {
+    fontDirectories = [ dejavu_fonts ];
+  };
 in
   pkgs.stdenv.mkDerivation {
     name = "wiwinwlh-env";
     buildInputs = [ ghcWithDeps tex ];
+    FONTCONFIG_FILE = fontsConf;
     shellHook = ''
       export LANG=en_US.UTF-8
       eval $(egrep ^export ${ghcWithDeps}/bin/ghc)

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,7 @@ let
     inherit (texlive)
       scheme-small
       xetex
+      newunicodechar
       ;
   };
   fontsConf = makeFontsConf {


### PR DESCRIPTION
Hello Stephen,

it took a bit of trying, but I was able to render the PDF with all symbols showing correctly! I needed to replace the monospaced font (I chose DejaVu Sans Mono after playing around with what's available - it was the only font that had most unicode characters). I tweaked the nix shell to fetch it.
There were still some fonts missing (like adjunction/disjunction), and after some searching, I found that this was [only possible](https://tex.stackexchange.com/questions/99760/utf-8-characters-not-displayed-with-xelatex-pandoc/99857#99857) by including a custom mapping using the `newunicodechar` package).

Now, the PDF is rendered using all symbols!
![image](https://user-images.githubusercontent.com/601206/72473433-5c17da80-37ef-11ea-8ca1-b8b5591cd4fa.png)
