### PR TITLE
Update type in aeson_structured example

### DIFF
--- a/src/26-data-formats/aeson_structured.hs
+++ b/src/26-data-formats/aeson_structured.hs
@@ -15,7 +15,7 @@ data Refs = Refs
 data Data = Data
   { id    :: Int
   , name  :: Text
-  , price :: Int
+  , price :: Float
   , tags  :: [Text]
   , refs  :: Refs
   } deriving (Show,Generic)


### PR DESCRIPTION
This change fixes the aeson structured example where
price does not decode as Int.