### PR TITLE
Fix conversion table layout in String Convertions chapter

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -7140,13 +7140,14 @@ with several functions across the bytestring and text libraries. The mapping
 between text and bytestring is inherently lossy so there is some degree of
 freedom in choosing the encoding. We'll just consider utf-8 for simplicity.
 
-(From : left column,  To : top row)
                       Data.Text  Data.Text.Lazy  Data.ByteString  Data.ByteString.Lazy
 --------------------- ---------  --------------  ---------------  ------------------
 Data.Text             id         fromStrict      encodeUtf8       encodeUtf8
 Data.Text.Lazy        toStrict   id              encodeUtf8       encodeUtf8
 Data.ByteString       decodeUtf8 decodeUtf8      id               fromStrict
 Data.ByteString.Lazy  decodeUtf8 decodeUtf8      toStrict         id
+
+Table: From : left column,  To : top row
 
 Be careful with the functions (`decodeUtf8`, `decodeUtf16LE`, etc.) as they are
 partial and will throw errors if the byte array given does not contain unicode


### PR DESCRIPTION
Table in "String Conversion" chapter is rendered this way in HTML:
<img width="831" alt="Screenshot 2020-03-20 at 00 23 40" src="https://user-images.githubusercontent.com/166523/77116320-0f47be80-6a41-11ea-98f9-49434bebdebf.png">
and this way in EPUB (missing From/To comment)
<img width="590" alt="Screenshot 2020-03-20 at 00 25 46" src="https://user-images.githubusercontent.com/166523/77116498-5930a480-6a41-11ea-9c6d-c6d7ab629fe5.png">

Looks like it's broken in HTML because table in markdown is not separated from "From/To" comment by an empty line. I thought that comment might make a good caption, and moved it to table section, and now it looks like this in HTML:
<img width="824" alt="Screenshot 2020-03-20 at 00 28 31" src="https://user-images.githubusercontent.com/166523/77116756-baf10e80-6a41-11ea-8a2e-9fe7ba988948.png">
and in EPUB:
<img width="602" alt="Screenshot 2020-03-20 at 00 28 46" src="https://user-images.githubusercontent.com/166523/77116771-c47a7680-6a41-11ea-8f25-6a9e0d5b696f.png">

If you want I could put it back as a separate paragraph before the table with an empty line to just fix rendering in HTML.