### PR TITLE
Update `stack list-dependencies`

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -746,7 +746,7 @@ $ stack install hlint
 To check the set of dependencies, run:
 
 ```bash
-$ stack list-dependencies
+$ stack ls dependencies
 ```
 
 Just as with ``cabal``,  the build and debug process can be orchestrated using


### PR DESCRIPTION
Updated `stack list-dependencies` to `stack ls dependencies`, `list-dependencies` is deprecated since stack v1.7 and was removed in stack v2.1.0.1 - see https://github.com/commercialhaskell/stack/releases/tag/v2.1.0.1