### PR TITLE
Fix duplicate 'that' in subsection Repline

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,16 @@
-2013-2020 Stephen Diehl
+Copyright © 2009-2020 Stephen Diehl
 
-The person who associated a work with this deed has dedicated the work
-to the public domain by waiving all of his or her rights to the work
-worldwide under copyright law, including all related and neighboring
-rights, to the extent allowed by law.
+This code included in the text is dedicated to the public domain. You can copy,
+modify, distribute and perform the code, even for commercial purposes, all
+without asking permission.
 
-You can copy, modify, distribute and perform the work, even for
-commercial purposes, all without asking permission.
+You may distribute this text in its full form freely, but may not reauthor or
+sublicense this work. Any reproductions of major portions of the text must
+include attribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The software is provided "as is", without warranty of any kind, express or
+implied, including But not limited to the warranties of merchantability, fitness
+for a particular purpose and noninfringement. In no event shall the authors or
+copyright holders be liable for any claim, damages or other liability, whether
+in an action of contract, tort or otherwise, Arising from, out of or in
+connection with the software or the use or other dealings in the software.

--- a/tutorial.md
+++ b/tutorial.md
@@ -6970,6 +6970,26 @@ of any data structure which is parameterized over its element type ( List, Map,
 Set, Maybe, ...). These two classes are used everywhere in modern Haskell
 and are extremely important.
 
+```haskell
+class Foldable t where
+  fold    :: Monoid m => t m -> m
+  foldMap :: Monoid m => (a -> m) -> t a -> m
+  foldr   :: (a -> b -> b) -> b -> t a -> b
+  foldr'  :: (a -> b -> b) -> b -> t a -> b
+  foldl   :: (b -> a -> b) -> b -> t a -> b
+  foldl'  :: (b -> a -> b) -> b -> t a -> b
+  foldr1  :: (a -> a -> a) -> t a -> a
+  foldl1  :: (a -> a -> a) -> t a -> a
+  toList  :: t a -> [a]
+  null    :: t a -> Bool
+  length  :: t a -> Int
+  elem    :: Eq a => a -> t a -> Bool
+  maximum :: Ord a => t a -> a
+  minimum :: Ord a => t a -> a
+  sum     :: Num a => t a -> a
+  product :: Num a => t a -> a
+```
+
 A foldable instance allows us to apply functions to data types of monoidal
 values that collapse the structure using some logic over ``mappend``.
 
@@ -7025,21 +7045,6 @@ newtype Endo a = Endo {appEndo :: a -> a}
 instance Monoid (Endo a) where
   mempty = Endo id
   Endo f `mappend` Endo g = Endo (f . g)
-```
-
-```haskell
-class Foldable t where
-    fold    :: Monoid m => t m -> m
-    foldMap :: Monoid m => (a -> m) -> t a -> m
-
-    foldr   :: (a -> b -> b) -> b -> t a -> b
-    foldr'  :: (a -> b -> b) -> b -> t a -> b
-
-    foldl   :: (b -> a -> b) -> b -> t a -> b
-    foldl'  :: (b -> a -> b) -> b -> t a -> b
-
-    foldr1  :: (a -> a -> a) -> t a -> a
-    foldl1  :: (a -> a -> a) -> t a -> a
 ```
 
 For example:


### PR DESCRIPTION
Fixes:
> To that end Repline assists in building interactive shells **that that** resemble GHCi’s default behavior.

