### PR TITLE
prefix web address with https to avoid relative url

### DIFF
--- a/resources/copyright.html
+++ b/resources/copyright.html
@@ -15,7 +15,7 @@
 <h2 id="author">Author</h2>
 <p>This text is authored by Stephen Diehl.</p>
 <ul class="incremental">
-<li>Web: <a href="www.stephendiehl.com" class="uri">www.stephendiehl.com</a></li>
+<li>Web: <a href="https://www.stephendiehl.com" class="uri">https://www.stephendiehl.com</a></li>
 <li>Twitter: <a href="https://twitter.com/smdiehl" class="uri">https://twitter.com/smdiehl</a></li>
 <li>Github: <a href="https://github.com/sdiehl" class="uri">https://github.com/sdiehl</a></li>
 </ul>

--- a/resources/copyright.md
+++ b/resources/copyright.md
@@ -24,7 +24,7 @@ Author
 
 This text is authored by Stephen Diehl.
 
-* Web: [www.stephendiehl.com](www.stephendiehl.com)
+* Web: [https://www.stephendiehl.com](https://www.stephendiehl.com)
 * Twitter: [https://twitter.com/smdiehl](https://twitter.com/smdiehl)
 * Github: [https://github.com/sdiehl](https://github.com/sdiehl)
 

--- a/resources/copyright.tex
+++ b/resources/copyright.tex
@@ -27,7 +27,7 @@ https://github.com/sdiehl/wiwinwlh
 This text is authored by Stephen Diehl.
 
 \begin{enumerate}
-\item Web: www.stephendiehl.com
+\item Web: https://www.stephendiehl.com
 \item Twitter: https://twitter.com/smdiehl
 \item Github: https://github.com/sdiehl
 \end{enumerate}


### PR DESCRIPTION
Without prefixing the provided URL the generated URL will be relative to the site it is being served from. E.g. http://dev.stephendiehl.com/hask/www.stephendiehl.com when being served via http://dev.stephendiehl.com/hask/

Changed also .html and .tex for consistency. Didn't see on first look if these get generated from the markdown one.