### PR TITLE
Fix typo, assitance -> assistance

### DIFF
--- a/resources/copyright.html
+++ b/resources/copyright.html
@@ -19,7 +19,7 @@
 <li>Twitter: <a href="https://twitter.com/smdiehl" class="uri">https://twitter.com/smdiehl</a></li>
 <li>Github: <a href="https://github.com/sdiehl" class="uri">https://github.com/sdiehl</a></li>
 </ul>
-<p>Special thanks for Erik Aker for copyediting assitance.</p>
+<p>Special thanks for Erik Aker for copyediting assistance.</p>
 <h2 id="license">License</h2>
 <p>Copyright © 2009-2020 Stephen Diehl</p>
 <p>This code included in the text is dedicated to the public domain. You can copy, modify, distribute and perform the code, even for commercial purposes, all without asking permission.</p>


### PR DESCRIPTION
Since this typo is not present in copyright.md or copyright.tex, this suggests that

1) If copyright.html is generated from either, this generation did not take place,
2) If the three versions are maintained separately, maybe other discrepancies exist.

Without knowing more, this fixes the typo present.