### PR TITLE
disable ligatures in code

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,6 +52,7 @@ pre.sourceCode {
 code {
   color: inherit;
   background-color: inherit;
+  font-variant-ligatures: none;
 }
 
 pre code {


### PR DESCRIPTION
In Chrome on MacOS, I see:
<img width="813" alt="Screen Shot 2020-08-28 at 8 28 22 PM" src="https://user-images.githubusercontent.com/261693/91628649-a90f8200-e976-11ea-92b1-e23db2c392ad.png">

The ligature in `-fforce-recomp` is jarring.

**Note:** this change is untested; I couldn't find instructions on how to set up my dev environment to produce the HTML content locally.