### PR TITLE
Remove foldr, foldr', foldl, foldl' from list of partial functions.

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -6802,10 +6802,6 @@ A list of partial functions in the default prelude:
 * ``init``
 * ``tail``
 * ``last``
-* ``foldl``
-* ``foldr``
-* ``foldl'``
-* ``foldr'``
 * ``foldr1``
 * ``foldl1``
 * ``cycle``


### PR DESCRIPTION
Hello,

First, thank you for writing this guide. I've found it quite helpful in filling some gaps in my Haskell knowledge.

I'm submitting this PR because, while I completely agree that `foldr1` and `foldl1` are partial functions for empty lists, I would be greatly surprised to learn that `foldl`, `foldl'`, `foldr`, and `foldr'` are not total functions in Haskell.  I suspect they were included in this list by mistake?

Thanks.