### PR TITLE
Fix overloaded labels example

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -5900,7 +5900,9 @@ extract = #id
 
 ```haskell
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -5912,7 +5914,7 @@ data S = MkS { foo :: Int }
 data T x y z = forall b . MkT { foo :: y, bar :: b }
 
 instance HasField x r a => IsLabel x (r -> a) where
-  fromLabel = getField
+  fromLabel = getField @x
 
 main :: IO ()
 main = do


### PR DESCRIPTION
The tutorial example using overloaded labels to access record fields would not compile, so I synchronized it with the code in `src/03-monad-transformers/overloaded_labels.hs`.